### PR TITLE
[Fixed] warning: mnemonic b not found in menu caption Back There

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -7,7 +7,7 @@
         [
             {
                 "caption": "Back There",
-                "mnemonic": "b",
+                "mnemonic": "B",
                 "id": "gobackthere",
                 "children":
                 [


### PR DESCRIPTION
See also [**similar pull request**](https://github.com/Doi9t/SortBy/pull/15).

### 1. Before

1. I get in Sublime Text console:

```
warning: mnemonic b not found in menu caption Back There
```

2. <kbd>Alt+G</kbd> → I press `B` any times → I can not select `Back There` item.

### 2. After

1. I don't get `Back There` warnings in console.
2. <kbd>Alt+G</kbd> → I press `B` any times → I can select `Back There` item.

Thanks.
